### PR TITLE
Adding container_start_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ecs_additional_iam_statements = [
 | ecs_associate_public_ip_address | Whether to associate a public IP in the launch configuration | bool | false | no | 
 | ecs_additional_iam_statements | Additional IAM statements for the ECS instances | list(object) | [] | no |
 | tags | A map of tags to add to all resources | map(string) | {} | no |
+| container_start_timeout | Timeout in minutes allowed for a contaner to startup | string | 3m | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ data "aws_ami" "latest_ecs_ami" {
 }
 
 data "template_file" "user_data-default" {
-  count = var.attach_efs ? 0 : 1
+  count    = var.attach_efs ? 0 : 1
   template = <<EOF
 Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 MIME-Version: 1.0
@@ -26,20 +26,22 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
 # Set any ECS agent configuration options
 echo "ECS_CLUSTER=$${ecs_cluster_name}" >> /etc/ecs/ecs.config
+echo "ECS_CONTAINER_START_TIMEOUT=$${container_start_timeout}" >> /etc/ecs/ecs.config
 
 --==BOUNDARY==--
 
 EOF
 
   vars = {
-    ecs_cluster_name = aws_ecs_cluster.this.name
+    ecs_cluster_name        = aws_ecs_cluster.this.name
+    container_start_timeout = var.container_start_timeout
   }
 }
 
 data "template_file" "user_data-efs" {
   depends_on = [var.depends_on_efs]
-  count = var.attach_efs ? 1 : 0
-  template = <<EOF
+  count      = var.attach_efs ? 1 : 0
+  template   = <<EOF
 Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 MIME-Version: 1.0
 
@@ -63,14 +65,16 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
 # Set any ECS agent configuration options
 echo "ECS_CLUSTER=$${ecs_cluster_name}" >> /etc/ecs/ecs.config
+echo "ECS_CONTAINER_START_TIMEOUT=$${container_start_timeout}" >> /etc/ecs/ecs.config
 
 --==BOUNDARY==--
 
 EOF
 
   vars = {
-    ecs_cluster_name = aws_ecs_cluster.this.name
-    efs_id           = var.efs_id
+    ecs_cluster_name        = aws_ecs_cluster.this.name
+    efs_id                  = var.efs_id
+    container_start_timeout = var.container_start_timeout
   }
 }
 
@@ -221,8 +225,8 @@ data "aws_iam_policy_document" "policy" {
   dynamic "statement" {
     for_each = var.ecs_additional_iam_statements
     content {
-      effect = lookup(statement.value, "effect", null)
-      actions = lookup(statement.value, "actions", null)
+      effect    = lookup(statement.value, "effect", null)
+      actions   = lookup(statement.value, "actions", null)
       resources = lookup(statement.value, "resources", null)
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@
 #------------------------------------------------------------------------------
 variable "depends_on_efs" {
   description = "If attaching EFS, it makes sure that the mount targets are ready"
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "vpc_id" {
@@ -90,9 +90,15 @@ variable "ecs_associate_public_ip_address" {
 variable "ecs_additional_iam_statements" {
   description = "Additional IAM statements for the ECS instances"
   type = list(object({
-    effect = string
-    actions = list(string)
+    effect    = string
+    actions   = list(string)
     resources = list(string)
   }))
   default = []
+}
+
+variable "container_start_timeout" {
+  description = "Adjust the timeout for a container starting, expressed in minutes. For example 10m"
+  type        = string
+  default     = "3m"
 }


### PR DESCRIPTION
Adding this to configure the ECS agent to change the timeout
for containers to start. This is useful for larger container
downloads or containers that have a long initial startup
procedure.

Updated documentation and code.